### PR TITLE
Fix typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Aloca Rec
 
-Este é um projeto usando o framework Fastify com TypeScrip e PostgreSQL com Prisma. 
+Este é um projeto usando o framework Fastify com TypeScript e PostgreSQL com Prisma.
 
 # Participantes do grupo
 Nathan Dame Abreu


### PR DESCRIPTION
## Summary
- fix minor TypeScript typo in readme

## Testing
- `npm test` *(fails: cannot read properties of undefined, expected 403 vs 201 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68421e1beff4833195ce57522426ca54