### PR TITLE
Fix numeric ID schema for reserva routes

### DIFF
--- a/src/domains/reserva/reserva-routes.ts
+++ b/src/domains/reserva/reserva-routes.ts
@@ -75,7 +75,7 @@ export default async function reservaRoutes(app: FastifyInstance) {
         type: 'object',
         required: ['id'],
         properties: {
-          id: { type: 'string' }
+          id: { type: 'number' }
         }
       },
       response: {
@@ -107,7 +107,7 @@ export default async function reservaRoutes(app: FastifyInstance) {
       type: 'object',
       required: ['id'],
       properties: {
-        id: { type: 'string' }
+        id: { type: 'number' }
       }
     },
     body: {
@@ -146,7 +146,7 @@ export default async function reservaRoutes(app: FastifyInstance) {
       type: 'object',
       required: ['id'],
       properties: {
-        id: { type: 'string' }
+        id: { type: 'number' }
       }
     },
     response: {


### PR DESCRIPTION
## Summary
- update all reserva routes to treat IDs as numbers

## Testing
- `npm test` *(fails: PedidoService etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68421e233e3c833192b936a9928fdb58