### PR TITLE
Fix Status enum in prisma mock

### DIFF
--- a/__tests__/domains/pedido/pedido.repository.spec.ts
+++ b/__tests__/domains/pedido/pedido.repository.spec.ts
@@ -12,6 +12,11 @@ jest.mock('@prisma/client', () => ({
       delete: jest.fn(),
     },
   })),
+  Status: {
+    PENDENTE: 'PENDENTE',
+    APROVADA: 'APROVADA',
+    REJEITADA: 'REJEITADA',
+  },
 }));
 
 describe('PedidoRepository', () => {


### PR DESCRIPTION
## Summary
- expose Status enum in Prisma client jest mock so tests can reference it

## Testing
- `npm test` *(fails: Service errors)*

------
https://chatgpt.com/codex/tasks/task_e_68422044686883318c72e3d17f7e88ac