### PR TITLE
Fix remove repository test

### DIFF
--- a/__tests__/domains/pedido/pedido.repository.spec.ts
+++ b/__tests__/domains/pedido/pedido.repository.spec.ts
@@ -162,18 +162,18 @@ describe('PedidoRepository', () => {
 
       const result = await PedidoRepository.remove(1);
 
-      expect(result).toBe(true);
+      expect(result).toEqual(mockPedido);
       expect(prisma.pedido.delete).toHaveBeenCalledWith({
         where: { id: 1 },
       });
     });
 
-    it('deve retornar false quando pedido não encontrado', async () => {
+    it('deve propagar erro quando pedido não encontrado', async () => {
       (prisma.pedido.delete as jest.Mock).mockRejectedValueOnce(new Error('Record to delete does not exist'));
 
-      const result = await PedidoRepository.remove(999);
-
-      expect(result).toBe(false);
+      await expect(PedidoRepository.remove(999))
+        .rejects
+        .toThrow('Record to delete does not exist');
     });
   });
 }); 


### PR DESCRIPTION
## Summary
- correct expectations in `PedidoRepository` remove tests

## Testing
- `npm test` *(fails: cannot read properties of undefined and HTTP 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684220477dcc8331bc4898bbef2c0501