### PR TITLE
Improve validation in user and room forms

### DIFF
--- a/web/src/views/SalasForm.tsx
+++ b/web/src/views/SalasForm.tsx
@@ -92,6 +92,8 @@ export default function SalasForm() {
         setShowForm(false);
         setEditando(null);
         carregarSalas();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso n\u00e3o autorizado. Faça login novamente.");
       } else {
         setError(data.message || "Erro ao salvar sala");
       }
@@ -122,6 +124,8 @@ export default function SalasForm() {
       });
       if (res.ok) {
         carregarSalas();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso n\u00e3o autorizado. Faça login novamente.");
       } else {
         setError("Erro ao remover sala");
       }
@@ -190,6 +194,7 @@ export default function SalasForm() {
             <Input
               label="Capacidade"
               type="number"
+              min={1}
               value={capacidade}
               onChange={e => setCapacidade(e.target.value)}
               required

--- a/web/src/views/UsuariosForm.tsx
+++ b/web/src/views/UsuariosForm.tsx
@@ -102,6 +102,8 @@ export default function UsuariosForm() {
         setEditando(null);
         // Recarregar lista
         carregarUsuarios();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso n\u00e3o autorizado. Faça login novamente.");
       } else {
         setError(data.message || "Erro ao salvar usuário");
       }
@@ -134,6 +136,8 @@ export default function UsuariosForm() {
       
       if (res.ok) {
         carregarUsuarios();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso n\u00e3o autorizado. Faça login novamente.");
       } else {
         setError("Erro ao remover usuário");
       }
@@ -204,6 +208,7 @@ export default function UsuariosForm() {
             <Input
               label="Email"
               type="email"
+              pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$"
               value={email}
               onChange={e => setEmail(e.target.value)}
               required
@@ -212,6 +217,7 @@ export default function UsuariosForm() {
               <Input
                 label="Senha"
                 type="password"
+                minLength={6}
                 value={senha}
                 onChange={e => setSenha(e.target.value)}
                 required


### PR DESCRIPTION
## Summary
- tighten email and password inputs on the Users form
- add minimum capacity check on the Rooms form
- show specific messages when authorization fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1119c0e0833191eac60ad08a0e0f