### PR TITLE
Update Postman examples for user fields

### DIFF
--- a/alocarec-api.postman_collection.json
+++ b/alocarec-api.postman_collection.json
@@ -68,7 +68,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"nome\": \"Nome do Usuário\",\n    \"email\": \"usuario@exemplo.com\",\n    \"senha\": \"senha123\",\n    \"perfilId\": 1\n}"
+							"raw": "{\n    \"nome\": \"Nome do Usuário\",\n    \"email\": \"usuario@exemplo.com\",\n    \"dataNascimento\": \"1990-01-01T00:00:00Z\",\n    \"sexo\": \"M\",\n    \"telefones\": [{ \"numero\": \"51999999999\", \"descricao\": \"Principal\" }],\n    \"senha\": \"senha123\",\n    \"perfilId\": 1\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/usuarios",
@@ -116,7 +116,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"nome\": \"Nome Atualizado\",\n    \"email\": \"atualizado@exemplo.com\",\n    \"perfilId\": 1\n}"
+							"raw": "{\n    \"nome\": \"Nome Atualizado\",\n    \"email\": \"atualizado@exemplo.com\",\n    \"dataNascimento\": \"1990-01-01T00:00:00Z\",\n    \"sexo\": \"F\",\n    \"telefones\": [{ \"numero\": \"51988888888\", \"descricao\": \"Principal\" }],\n    \"perfilId\": 1\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/usuarios/:id",


### PR DESCRIPTION
## Summary
- document `dataNascimento`, `sexo` and `telefones` in Postman collection examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b146f8520833186742d7588a59d45