### PR TITLE
Add reserva conflict check

### DIFF
--- a/__tests__/domains/reserva/reserva.repository.spec.ts
+++ b/__tests__/domains/reserva/reserva.repository.spec.ts
@@ -1,7 +1,14 @@
 import { prisma } from '../../../src/config/database';
 import * as ReservaRepository from '../../../src/domains/reserva/reserva-repository';
 
-jest.mock('../../../src/config/database', () => ({ prisma: { reserva: { create: jest.fn() } } }));
+jest.mock('../../../src/config/database', () => ({
+  prisma: {
+    reserva: {
+      create: jest.fn(),
+      findFirst: jest.fn()
+    }
+  }
+}));
 
 describe('ReservaRepository', () => {
   it('createReserva utiliza prisma', async () => {
@@ -13,5 +20,18 @@ describe('ReservaRepository', () => {
 
     expect(result).toEqual(res);
     expect(prisma.reserva.create).toHaveBeenCalledWith({ data: input, include: { sala: true, usuario: true } });
+  });
+
+  it('findReservaBySalaAndDataHora utiliza prisma', async () => {
+    const res = { id: 1, salaId: 1, usuarioId: 1, dataHora: '2024-01-01T00:00:00Z' };
+    (prisma.reserva.findFirst as jest.Mock).mockResolvedValueOnce(res);
+
+    const result = await ReservaRepository.findReservaBySalaAndDataHora(1, '2024-01-01T00:00:00Z');
+
+    expect(result).toEqual(res);
+    expect(prisma.reserva.findFirst).toHaveBeenCalledWith({
+      where: { salaId: 1, dataHora: new Date('2024-01-01T00:00:00Z') },
+      include: { sala: true, usuario: true }
+    });
   });
 });

--- a/__tests__/domains/reserva/reserva.service.spec.ts
+++ b/__tests__/domains/reserva/reserva.service.spec.ts
@@ -1,5 +1,5 @@
 import * as ReservaRepository from '../../../src/domains/reserva/reserva-repository';
-import { createReservaService } from '../../../src/domains/reserva/reserva-service';
+import { createReservaService, updateReservaService } from '../../../src/domains/reserva/reserva-service';
 
 jest.mock('../../../src/domains/reserva/reserva-repository');
 
@@ -13,5 +13,20 @@ describe('ReservaService', () => {
 
     expect(result).toBeDefined();
     expect(ReservaRepository.createReserva).toHaveBeenCalledWith(input);
+  });
+
+  it('deve rejeitar reserva em conflito', async () => {
+    const input = { salaId: 1, usuarioId: 1, dataHora: '2024-01-01T00:00:00Z' } as any;
+    (ReservaRepository.findReservaBySalaAndDataHora as jest.Mock).mockResolvedValueOnce({ id: 2 });
+
+    await expect(createReservaService(input)).rejects.toThrow('Já existe uma reserva para esta sala neste horário');
+  });
+
+  it('deve rejeitar update em conflito', async () => {
+    const current = { id: 1, salaId: 1, usuarioId: 1, dataHora: '2024-01-01T00:00:00Z' };
+    (ReservaRepository.findReservaById as jest.Mock).mockResolvedValueOnce(current);
+    (ReservaRepository.findReservaBySalaAndDataHora as jest.Mock).mockResolvedValueOnce({ id: 2 });
+
+    await expect(updateReservaService(1, { dataHora: '2024-01-02T00:00:00Z' })).rejects.toThrow('Já existe uma reserva para esta sala neste horário');
   });
 });

--- a/src/domains/reserva/reserva-repository.ts
+++ b/src/domains/reserva/reserva-repository.ts
@@ -31,6 +31,17 @@ export async function findReservaById(id: number): Promise<Reserva | null> {
   return reserva ? toReserva(reserva) : null;
 }
 
+export async function findReservaBySalaAndDataHora(
+  salaId: number,
+  dataHora: string
+): Promise<Reserva | null> {
+  const reserva = await prisma.reserva.findFirst({
+    where: { salaId, dataHora: new Date(dataHora) },
+    include: { sala: true, usuario: true }
+  });
+  return reserva ? toReserva(reserva) : null;
+}
+
 export async function updateReserva(id: number, data: UpdateReservaInput): Promise<Reserva> {
   const reserva = await prisma.reserva.update({
     where: { id },


### PR DESCRIPTION
## Summary
- prevent overlapping reservas
- test create/update reservation conflicts

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b17588cac8331bc6b72dedddab58a