### PR TITLE
Fix reservation datetime payload

### DIFF
--- a/web/src/views/ReservasForm.tsx
+++ b/web/src/views/ReservasForm.tsx
@@ -93,7 +93,7 @@ export default function ReservasForm() {
         body: JSON.stringify({
           salaId,
           usuarioId,
-          dataHora,
+          dataHora: new Date(dataHora).toISOString(),
         }),
       });
       const data = await res.json();


### PR DESCRIPTION
## Summary
- convert `dataHora` to ISO string when submitting the reservation form

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b19d079148331a7ab7bea40e5b657