### PR TITLE
Add UI pages for additional entities

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -41,8 +41,10 @@ export default function RootLayout({
           <Link href="/">Início</Link> |
           <Link href="/usuarios" style={{ marginLeft: 8 }}>Usuários</Link> |
           <Link href="/salas" style={{ marginLeft: 8 }}>Salas</Link> |
+          <Link href="/predios" style={{ marginLeft: 8 }}>Prédios</Link> |
           <Link href="/reservas" style={{ marginLeft: 8 }}>Reservas</Link> |
           <Link href="/recursos" style={{ marginLeft: 8 }}>Recursos</Link> |
+          <Link href="/tipos-recurso" style={{ marginLeft: 8 }}>Tipos</Link> |
           {isLogged ? (
             <a href="/logout" style={{ marginLeft: 8 }}>Logout</a>
           ) : (

--- a/web/src/app/logout/page.tsx
+++ b/web/src/app/logout/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect } from "react";
+
+export default function LogoutPage() {
+  useEffect(() => {
+    document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+    window.location.href = "/login";
+  }, []);
+
+  return <p style={{ padding: 20 }}>Saindo...</p>;
+}

--- a/web/src/app/predios/page.tsx
+++ b/web/src/app/predios/page.tsx
@@ -1,0 +1,5 @@
+import PrediosForm from "@/views/PrediosForm";
+
+export default function PrediosPage() {
+  return <PrediosForm />;
+}

--- a/web/src/app/recursos/page.tsx
+++ b/web/src/app/recursos/page.tsx
@@ -1,0 +1,5 @@
+import RecursosForm from "@/views/RecursosForm";
+
+export default function RecursosPage() {
+  return <RecursosForm />;
+}

--- a/web/src/app/tipos-recurso/page.tsx
+++ b/web/src/app/tipos-recurso/page.tsx
@@ -1,0 +1,5 @@
+import TipoRecursoForm from "@/views/TipoRecursoForm";
+
+export default function TipoRecursoPage() {
+  return <TipoRecursoForm />;
+}

--- a/web/src/views/PrediosForm.tsx
+++ b/web/src/views/PrediosForm.tsx
@@ -1,0 +1,262 @@
+"use client";
+import { useState, useEffect } from "react";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import Card from "@/components/Card";
+import { getToken } from "@/helpers/auth";
+
+export default function PrediosForm() {
+  const [predios, setPredios] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showForm, setShowForm] = useState(false);
+  const [numero, setNumero] = useState("");
+  const [nome, setNome] = useState("");
+  const [descricao, setDescricao] = useState("");
+  const [rua, setRua] = useState("");
+  const [numeroEndereco, setNumeroEndereco] = useState("");
+  const [complemento, setComplemento] = useState("");
+  const [bairro, setBairro] = useState("");
+  const [cidade, setCidade] = useState("");
+  const [uf, setUf] = useState("");
+  const [cep, setCep] = useState("");
+  const [editando, setEditando] = useState<any | null>(null);
+
+  async function carregarPredios() {
+    setLoading(true);
+    try {
+      const token = getToken();
+      const res = await fetch("http://localhost:3000/predios", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setPredios(data);
+      } else {
+        setError("Erro ao carregar prédios");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    carregarPredios();
+  }, []);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const token = getToken();
+      const url = editando
+        ? `http://localhost:3000/predios/${editando.id}`
+        : "http://localhost:3000/predios";
+      const method = editando ? "PUT" : "POST";
+      const res = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          numero,
+          nome,
+          descricao,
+          rua,
+          numero_endereco: numeroEndereco,
+          complemento,
+          bairro,
+          cidade,
+          uf,
+          cep,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        limparForm();
+        setShowForm(false);
+        setEditando(null);
+        carregarPredios();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso não autorizado. Faça login novamente.");
+      } else {
+        setError(data.message || "Erro ao salvar prédio");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleEditar(predio: any) {
+    setEditando(predio);
+    setNumero(predio.numero);
+    setNome(predio.nome);
+    setDescricao(predio.descricao || "");
+    setRua(predio.rua);
+    setNumeroEndereco(predio.numero_endereco);
+    setComplemento(predio.complemento || "");
+    setBairro(predio.bairro);
+    setCidade(predio.cidade);
+    setUf(predio.uf);
+    setCep(predio.cep);
+    setShowForm(true);
+  }
+
+  async function handleRemover(id: number) {
+    if (!confirm("Tem certeza que deseja remover?")) return;
+    try {
+      const token = getToken();
+      const res = await fetch(`http://localhost:3000/predios/${id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        carregarPredios();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso não autorizado. Faça login novamente.");
+      } else {
+        setError("Erro ao remover prédio");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    }
+  }
+
+  function limparForm() {
+    setNumero("");
+    setNome("");
+    setDescricao("");
+    setRua("");
+    setNumeroEndereco("");
+    setComplemento("");
+    setBairro("");
+    setCidade("");
+    setUf("");
+    setCep("");
+  }
+
+  function handleCancelar() {
+    setShowForm(false);
+    setEditando(null);
+    limparForm();
+    setError(null);
+  }
+
+  function handleNovo() {
+    setShowForm(true);
+    setEditando(null);
+    limparForm();
+  }
+
+  return (
+    <div style={{ padding: "20px", maxWidth: "1200px", margin: "0 auto" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "24px",
+        }}
+      >
+        <h1>🏢 Prédios</h1>
+        {!showForm && (
+          <Button onClick={handleNovo} style={{ background: "#28a745" }}>
+            ➕ Novo Prédio
+          </Button>
+        )}
+      </div>
+
+      {error && (
+        <div
+          style={{
+            background: "#f8d7da",
+            color: "#721c24",
+            padding: "12px",
+            borderRadius: "4px",
+            marginBottom: "16px",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {showForm ? (
+        <Card>
+          <h2>{editando ? "✏️ Editar Prédio" : "➕ Novo Prédio"}</h2>
+          <form onSubmit={handleSubmit}>
+            <Input label="Número" value={numero} onChange={e => setNumero(e.target.value)} required />
+            <Input label="Nome" value={nome} onChange={e => setNome(e.target.value)} required />
+            <Input label="Descrição" value={descricao} onChange={e => setDescricao(e.target.value)} />
+            <Input label="Rua" value={rua} onChange={e => setRua(e.target.value)} required />
+            <Input label="Número Endereço" value={numeroEndereco} onChange={e => setNumeroEndereco(e.target.value)} required />
+            <Input label="Complemento" value={complemento} onChange={e => setComplemento(e.target.value)} />
+            <Input label="Bairro" value={bairro} onChange={e => setBairro(e.target.value)} required />
+            <Input label="Cidade" value={cidade} onChange={e => setCidade(e.target.value)} required />
+            <Input label="UF" value={uf} onChange={e => setUf(e.target.value)} required />
+            <Input label="CEP" value={cep} onChange={e => setCep(e.target.value)} required />
+            <div style={{ display: "flex", gap: "8px" }}>
+              <Button type="submit" disabled={loading} style={{ flex: 1 }}>
+                {loading ? "Salvando..." : editando ? "Atualizar" : "Cadastrar"}
+              </Button>
+              <Button type="button" onClick={handleCancelar} style={{ flex: 1, background: "#6c757d" }}>
+                Cancelar
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : (
+        <div>
+          {loading ? (
+            <div style={{ textAlign: "center", padding: "40px" }}>Carregando...</div>
+          ) : predios.length === 0 ? (
+            <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
+              <p>Nenhum prédio cadastrado</p>
+              <Button onClick={handleNovo} style={{ background: "#28a745" }}>
+                ➕ Cadastrar primeiro prédio
+              </Button>
+            </div>
+          ) : (
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(350px, 1fr))",
+                gap: "16px",
+              }}
+            >
+              {predios.map(predio => (
+                <Card key={predio.id}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "16px" }}>
+                    <div>
+                      <h3 style={{ margin: "0 0 8px 0", color: "#333" }}>{predio.nome}</h3>
+                      <p style={{ margin: "0 0 4px 0", color: "#666" }}>
+                        <strong>Número:</strong> {predio.numero}
+                      </p>
+                      <p style={{ margin: "0 0 4px 0", color: "#666" }}>
+                        <strong>Cidade:</strong> {predio.cidade}
+                      </p>
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: "8px", borderTop: "1px solid #eee", paddingTop: "12px" }}>
+                    <Button onClick={() => handleEditar(predio)} style={{ background: "#0070f3", flex: 1 }}>
+                      ✏️ Editar
+                    </Button>
+                    <Button onClick={() => handleRemover(predio.id)} style={{ background: "#dc3545", flex: 1 }}>
+                      🗑️ Remover
+                    </Button>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/views/RecursosForm.tsx
+++ b/web/src/views/RecursosForm.tsx
@@ -1,0 +1,283 @@
+"use client";
+import { useState, useEffect } from "react";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import Card from "@/components/Card";
+import { getToken } from "@/helpers/auth";
+
+export default function RecursosForm() {
+  const [recursos, setRecursos] = useState<any[]>([]);
+  const [tipos, setTipos] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showForm, setShowForm] = useState(false);
+  const [descricao, setDescricao] = useState("");
+  const [status, setStatus] = useState("");
+  const [disponivel, setDisponivel] = useState(true);
+  const [tipoId, setTipoId] = useState(0);
+  const [editando, setEditando] = useState<any | null>(null);
+
+  async function carregarRecursos() {
+    setLoading(true);
+    try {
+      const token = getToken();
+      const res = await fetch("http://localhost:3000/recursos", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setRecursos(data);
+      } else {
+        setError("Erro ao carregar recursos");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function carregarTipos() {
+    try {
+      const token = getToken();
+      const res = await fetch("http://localhost:3000/tipos-recurso", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setTipos(data);
+      }
+    } catch (err) {
+      console.error("Erro ao carregar tipos");
+    }
+  }
+
+  useEffect(() => {
+    carregarRecursos();
+    carregarTipos();
+  }, []);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const token = getToken();
+      const url = editando
+        ? `http://localhost:3000/recursos/${editando.id}`
+        : "http://localhost:3000/recursos";
+      const method = editando ? "PUT" : "POST";
+      const res = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          descricao,
+          status,
+          disponivel,
+          tipo_recurso_id: tipoId,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        limparForm();
+        setShowForm(false);
+        setEditando(null);
+        carregarRecursos();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso não autorizado. Faça login novamente.");
+      } else {
+        setError(data.message || "Erro ao salvar recurso");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleEditar(recurso: any) {
+    setEditando(recurso);
+    setDescricao(recurso.descricao);
+    setStatus(recurso.status);
+    setDisponivel(recurso.disponivel);
+    setTipoId(recurso.tipo_recurso_id);
+    setShowForm(true);
+  }
+
+  async function handleRemover(id: number) {
+    if (!confirm("Tem certeza que deseja remover?")) return;
+    try {
+      const token = getToken();
+      const res = await fetch(`http://localhost:3000/recursos/${id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        carregarRecursos();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso não autorizado. Faça login novamente.");
+      } else {
+        setError("Erro ao remover recurso");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    }
+  }
+
+  function limparForm() {
+    setDescricao("");
+    setStatus("");
+    setDisponivel(true);
+    setTipoId(0);
+  }
+
+  function handleCancelar() {
+    setShowForm(false);
+    setEditando(null);
+    limparForm();
+    setError(null);
+  }
+
+  function handleNovo() {
+    setShowForm(true);
+    setEditando(null);
+    limparForm();
+  }
+
+  function nomeTipo(id: number) {
+    return tipos.find((t) => t.id === id)?.nome || id;
+  }
+
+  return (
+    <div style={{ padding: "20px", maxWidth: "1200px", margin: "0 auto" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "24px",
+        }}
+      >
+        <h1>📦 Recursos</h1>
+        {!showForm && (
+          <Button onClick={handleNovo} style={{ background: "#28a745" }}>
+            ➕ Novo Recurso
+          </Button>
+        )}
+      </div>
+
+      {error && (
+        <div
+          style={{
+            background: "#f8d7da",
+            color: "#721c24",
+            padding: "12px",
+            borderRadius: "4px",
+            marginBottom: "16px",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {showForm ? (
+        <Card>
+          <h2>{editando ? "✏️ Editar Recurso" : "➕ Novo Recurso"}</h2>
+          <form onSubmit={handleSubmit}>
+            <Input label="Descrição" value={descricao} onChange={e => setDescricao(e.target.value)} required />
+            <Input label="Status" value={status} onChange={e => setStatus(e.target.value)} required />
+            <div style={{ marginBottom: "12px" }}>
+              <label style={{ display: "block", marginBottom: "4px" }}>
+                Disponível
+              </label>
+              <input type="checkbox" checked={disponivel} onChange={e => setDisponivel(e.target.checked)} />
+            </div>
+            <div style={{ marginBottom: "12px" }}>
+              <label style={{ display: "block", marginBottom: "4px" }}>
+                Tipo *
+              </label>
+              <select
+                value={tipoId}
+                onChange={e => setTipoId(Number(e.target.value))}
+                style={{
+                  width: "100%",
+                  padding: "8px",
+                  border: "1px solid #ccc",
+                  borderRadius: "4px",
+                }}
+                required
+              >
+                <option value={0}>Selecione um tipo</option>
+                {tipos.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.nome}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div style={{ display: "flex", gap: "8px" }}>
+              <Button type="submit" disabled={loading} style={{ flex: 1 }}>
+                {loading ? "Salvando..." : editando ? "Atualizar" : "Cadastrar"}
+              </Button>
+              <Button type="button" onClick={handleCancelar} style={{ flex: 1, background: "#6c757d" }}>
+                Cancelar
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : (
+        <div>
+          {loading ? (
+            <div style={{ textAlign: "center", padding: "40px" }}>Carregando...</div>
+          ) : recursos.length === 0 ? (
+            <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
+              <p>Nenhum recurso cadastrado</p>
+              <Button onClick={handleNovo} style={{ background: "#28a745" }}>
+                ➕ Cadastrar primeiro recurso
+              </Button>
+            </div>
+          ) : (
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(350px, 1fr))",
+                gap: "16px",
+              }}
+            >
+              {recursos.map(recurso => (
+                <Card key={recurso.id}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "16px" }}>
+                    <div>
+                      <h3 style={{ margin: "0 0 8px 0", color: "#333" }}>{recurso.descricao}</h3>
+                      <p style={{ margin: "0 0 4px 0", color: "#666" }}>
+                        <strong>Status:</strong> {recurso.status}
+                      </p>
+                      <p style={{ margin: "0 0 4px 0", color: "#666" }}>
+                        <strong>Tipo:</strong> {nomeTipo(recurso.tipo_recurso_id)}
+                      </p>
+                      <p style={{ margin: "0 0 4px 0", color: "#666" }}>
+                        <strong>Disponível:</strong> {recurso.disponivel ? "Sim" : "Não"}
+                      </p>
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: "8px", borderTop: "1px solid #eee", paddingTop: "12px" }}>
+                    <Button onClick={() => handleEditar(recurso)} style={{ background: "#0070f3", flex: 1 }}>
+                      ✏️ Editar
+                    </Button>
+                    <Button onClick={() => handleRemover(recurso.id)} style={{ background: "#dc3545", flex: 1 }}>
+                      🗑️ Remover
+                    </Button>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/views/TipoRecursoForm.tsx
+++ b/web/src/views/TipoRecursoForm.tsx
@@ -1,0 +1,205 @@
+"use client";
+import { useState, useEffect } from "react";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import Card from "@/components/Card";
+import { getToken } from "@/helpers/auth";
+
+export default function TipoRecursoForm() {
+  const [tipos, setTipos] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showForm, setShowForm] = useState(false);
+  const [nome, setNome] = useState("");
+  const [editando, setEditando] = useState<any | null>(null);
+
+  async function carregarTipos() {
+    setLoading(true);
+    try {
+      const token = getToken();
+      const res = await fetch("http://localhost:3000/tipos-recurso", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setTipos(data);
+      } else {
+        setError("Erro ao carregar tipos");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    carregarTipos();
+  }, []);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const token = getToken();
+      const url = editando
+        ? `http://localhost:3000/tipos-recurso/${editando.id}`
+        : "http://localhost:3000/tipos-recurso";
+      const method = editando ? "PUT" : "POST";
+      const res = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ nome }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setNome("");
+        setShowForm(false);
+        setEditando(null);
+        carregarTipos();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso não autorizado. Faça login novamente.");
+      } else {
+        setError(data.message || "Erro ao salvar tipo de recurso");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleEditar(tipo: any) {
+    setEditando(tipo);
+    setNome(tipo.nome);
+    setShowForm(true);
+  }
+
+  async function handleRemover(id: number) {
+    if (!confirm("Tem certeza que deseja remover?")) return;
+    try {
+      const token = getToken();
+      const res = await fetch(`http://localhost:3000/tipos-recurso/${id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        carregarTipos();
+      } else if (res.status === 401 || res.status === 403) {
+        setError("Acesso não autorizado. Faça login novamente.");
+      } else {
+        setError("Erro ao remover tipo");
+      }
+    } catch (err) {
+      setError("Erro de conexão");
+    }
+  }
+
+  function handleCancelar() {
+    setShowForm(false);
+    setEditando(null);
+    setNome("");
+    setError(null);
+  }
+
+  function handleNovo() {
+    setShowForm(true);
+    setEditando(null);
+    setNome("");
+  }
+
+  return (
+    <div style={{ padding: "20px", maxWidth: "1200px", margin: "0 auto" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "24px",
+        }}
+      >
+        <h1>📁 Tipos de Recurso</h1>
+        {!showForm && (
+          <Button onClick={handleNovo} style={{ background: "#28a745" }}>
+            ➕ Novo Tipo
+          </Button>
+        )}
+      </div>
+
+      {error && (
+        <div
+          style={{
+            background: "#f8d7da",
+            color: "#721c24",
+            padding: "12px",
+            borderRadius: "4px",
+            marginBottom: "16px",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {showForm ? (
+        <Card>
+          <h2>{editando ? "✏️ Editar Tipo" : "➕ Novo Tipo"}</h2>
+          <form onSubmit={handleSubmit}>
+            <Input label="Nome" value={nome} onChange={e => setNome(e.target.value)} required />
+            <div style={{ display: "flex", gap: "8px" }}>
+              <Button type="submit" disabled={loading} style={{ flex: 1 }}>
+                {loading ? "Salvando..." : editando ? "Atualizar" : "Cadastrar"}
+              </Button>
+              <Button type="button" onClick={handleCancelar} style={{ flex: 1, background: "#6c757d" }}>
+                Cancelar
+              </Button>
+            </div>
+          </form>
+        </Card>
+      ) : (
+        <div>
+          {loading ? (
+            <div style={{ textAlign: "center", padding: "40px" }}>Carregando...</div>
+          ) : tipos.length === 0 ? (
+            <div style={{ textAlign: "center", padding: "40px", color: "#666" }}>
+              <p>Nenhum tipo cadastrado</p>
+              <Button onClick={handleNovo} style={{ background: "#28a745" }}>
+                ➕ Cadastrar primeiro tipo
+              </Button>
+            </div>
+          ) : (
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(350px, 1fr))",
+                gap: "16px",
+              }}
+            >
+              {tipos.map(tipo => (
+                <Card key={tipo.id}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "16px" }}>
+                    <div>
+                      <h3 style={{ margin: "0 0 8px 0", color: "#333" }}>{tipo.nome}</h3>
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: "8px", borderTop: "1px solid #eee", paddingTop: "12px" }}>
+                    <Button onClick={() => handleEditar(tipo)} style={{ background: "#0070f3", flex: 1 }}>
+                      ✏️ Editar
+                    </Button>
+                    <Button onClick={() => handleRemover(tipo.id)} style={{ background: "#dc3545", flex: 1 }}>
+                      🗑️ Remover
+                    </Button>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `PrediosForm`, `RecursosForm` and `TipoRecursoForm`
- add pages for `/predios`, `/recursos`, `/tipos-recurso` and a logout route
- update navigation links in layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b18c737948331bc55a6bb4ca3310c