### PR TITLE
Implement tipo recurso controller

### DIFF
--- a/__tests__/domains/tipo-recurso/tipo-recurso.controller.spec.ts
+++ b/__tests__/domains/tipo-recurso/tipo-recurso.controller.spec.ts
@@ -29,4 +29,60 @@ describe('TipoRecursoController', () => {
     expect(response.statusCode).toBe(201);
     expect(JSON.parse(response.payload)).toEqual(tipo);
   });
+
+  it('GET /tipos-recurso retorna todos', async () => {
+    const tipos: TipoRecursoResponseDTO[] = [{ id: 1, nome: 'Projetor' }];
+    (TipoService.getAllTipoRecursosService as jest.Mock).mockResolvedValueOnce(tipos);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/tipos-recurso',
+      headers: { authorization: 'Bearer token' }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toEqual(tipos);
+  });
+
+  it('GET /tipos-recurso/:id retorna tipo', async () => {
+    const tipo: TipoRecursoResponseDTO = { id: 1, nome: 'Projetor' };
+    (TipoService.getTipoRecursoByIdService as jest.Mock).mockResolvedValueOnce(tipo);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/tipos-recurso/1',
+      headers: { authorization: 'Bearer token' }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toEqual(tipo);
+  });
+
+  it('PUT /tipos-recurso/:id atualiza tipo', async () => {
+    const input = { nome: 'Atualizado' };
+    const tipo: TipoRecursoResponseDTO = { id: 1, nome: 'Atualizado' };
+    (TipoService.updateTipoRecursoService as jest.Mock).mockResolvedValueOnce(tipo);
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/tipos-recurso/1',
+      payload: input,
+      headers: { authorization: 'Bearer token' }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.payload)).toEqual(tipo);
+  });
+
+  it('DELETE /tipos-recurso/:id remove tipo', async () => {
+    (TipoService.deleteTipoRecursoService as jest.Mock).mockResolvedValueOnce(undefined);
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/tipos-recurso/1',
+      headers: { authorization: 'Bearer token' }
+    });
+
+    expect(response.statusCode).toBe(204);
+  });
 });

--- a/src/domains/tipo-recurso/tipo-recurso-controller.ts
+++ b/src/domains/tipo-recurso/tipo-recurso-controller.ts
@@ -1,23 +1,40 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import * as service from './tipo-recurso-service';
+import { UpdateTipoRecursoInput } from './tipo-recurso-entity';
 
 export async function createTipoRecursoController(request: FastifyRequest, reply: FastifyReply) {
     const tipo = await service.createTipoRecursoService(request.body as any);
     reply.code(201).send(tipo);
 }
 
-export async function getAllTipoRecursosController(request: FastifyRequest, reply: FastifyReply) {
-    reply.send('getAllTipoRecursosController');
+export async function getAllTipoRecursosController(
+    _request: FastifyRequest,
+    reply: FastifyReply
+) {
+    const tipos = await service.getAllTipoRecursosService();
+    return reply.send(tipos);
 }
 
-export async function getTipoRecursoByIdController(request: FastifyRequest, reply: FastifyReply) {
-    reply.send('getTipoRecursoByIdController');
+export async function getTipoRecursoByIdController(
+    request: FastifyRequest<{ Params: { id: number } }>,
+    reply: FastifyReply
+) {
+    const tipo = await service.getTipoRecursoByIdService(request.params.id);
+    return reply.send(tipo);
 }
 
-export async function updateTipoRecursoController(request: FastifyRequest, reply: FastifyReply) {
-    reply.send('updateTipoRecursoController');
+export async function updateTipoRecursoController(
+    request: FastifyRequest<{ Params: { id: number }; Body: UpdateTipoRecursoInput }>,
+    reply: FastifyReply
+) {
+    const tipo = await service.updateTipoRecursoService(request.params.id, request.body);
+    return reply.send(tipo);
 }
 
-export async function deleteTipoRecursoController(request: FastifyRequest, reply: FastifyReply) {
-    reply.send('deleteTipoRecursoController');
+export async function deleteTipoRecursoController(
+    request: FastifyRequest<{ Params: { id: number } }>,
+    reply: FastifyReply
+) {
+    await service.deleteTipoRecursoService(request.params.id);
+    return reply.code(204).send();
 }


### PR DESCRIPTION
## Summary
- implement missing TipoRecurso controller methods
- cover all TipoRecurso endpoints in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1d58b70883318d2b5034d02c0a1e