### PR TITLE
Add Jest pretest check and update docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "pretest": "node scripts/check-jest.js"
   },
   "dependencies": {
     "@fastify/cors": "^8.5.0",
@@ -42,4 +43,3 @@
     "typescript": "^5.4.0"
   }
 }
-

--- a/readme.md
+++ b/readme.md
@@ -74,3 +74,15 @@ http://localhost:3000/documentation/static/index.html#/usuarios/post_usuarios_lo
    ```
 
 > **Obs:** O arquivo `.env.aws` não é versionado. Use sempre o `.env.aws.example` como modelo.
+
+## Rodando os testes
+
+1. Instale as dependencias do projeto:
+   ```bash
+   npm install
+   ```
+2. Execute os testes:
+   ```bash
+   npm test
+   ```
+

--- a/scripts/check-jest.js
+++ b/scripts/check-jest.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+try {
+  require.resolve('jest');
+} catch (e) {
+  console.warn('Jest nao esta instalado. Execute `npm install` antes de rodar os testes.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- document running `npm install` before tests
- warn if Jest isn't installed via a pretest script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1db9c36c83319435597998f6bf11