### PR TITLE
Allow updating user phones and profile

### DIFF
--- a/__tests__/domains/usuario/usuario.repository.spec.ts
+++ b/__tests__/domains/usuario/usuario.repository.spec.ts
@@ -51,5 +51,41 @@ describe('UsuarioRepository', () => {
     });
   });
 
+  describe('updateUser', () => {
+    it('deve atualizar perfilId e telefones', async () => {
+      const updateInput = {
+        perfilId: 2,
+        telefones: [{ numero: '987654321', descricao: 'casa' }]
+      };
+
+      const mockUsuario: Usuario = {
+        id: 1,
+        email: 'teste@example.com',
+        nome: 'Usuario Teste',
+        dataNascimento: new Date('2024-01-01'),
+        sexo: Sexo.M,
+        perfilId: 2,
+        senha: 'senha123',
+        telefones: [{ id: 2, numero: '987654321', descricao: 'casa' }],
+        perfil: { id: 2, nome: 'Professor' }
+      };
+
+      (prisma.usuario.update as jest.Mock).mockResolvedValueOnce(mockUsuario);
+
+      const result = await UsuarioRepository.updateUser(1, updateInput);
+
+      expect(prisma.usuario.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 1 },
+          data: expect.objectContaining({
+            perfilId: 2,
+            telefones: { deleteMany: {}, create: updateInput.telefones }
+          })
+        })
+      );
+      expect(result).toEqual(mockUsuario);
+    });
+  });
+
   // ...outros testes para findUnique, findMany, update, delete...
 }); 

--- a/__tests__/domains/usuario/usuario.service.spec.ts
+++ b/__tests__/domains/usuario/usuario.service.spec.ts
@@ -55,6 +55,18 @@ describe('UsuarioService', () => {
       expect(UsuarioRepository.updateUser).toHaveBeenCalledWith(1, { senha: 'hashed' });
       expect(result).toEqual(expect.objectContaining({ email: mockUsuario.email }));
     });
+
+    it('deve atualizar perfilId e telefones', async () => {
+      (UsuarioRepository.updateUser as jest.Mock).mockResolvedValueOnce(mockUsuario);
+      const updateInput = {
+        perfilId: 2,
+        telefones: [{ numero: '987654321', descricao: 'casa' }]
+      };
+
+      await updateUserService(1, updateInput);
+
+      expect(UsuarioRepository.updateUser).toHaveBeenCalledWith(1, updateInput);
+    });
   });
 
   // ...outros testes para getUserByIdService, updateUserService, etc...

--- a/src/domains/usuario/usuario-repository.ts
+++ b/src/domains/usuario/usuario-repository.ts
@@ -43,14 +43,21 @@ export function getUserById(id: number): Promise<Usuario | null> {
 
 export function updateUser(id: number, data: UpdateUsuarioInput): Promise<Usuario | null> {
   const updateData: any = { ...data };
-  
-  // Remover campos que não devem ser atualizados diretamente
-  delete updateData.telefones;
-  delete updateData.perfilId;
-  
+
   if (updateData.sexo) updateData.sexo = updateData.sexo as Sexo;
   if (updateData.dataNascimento) updateData.dataNascimento = new Date(updateData.dataNascimento);
-  
+
+  if (data.telefones) {
+    updateData.telefones = {
+      deleteMany: {},
+      create: data.telefones
+    };
+  }
+
+  if (data.perfilId !== undefined) {
+    updateData.perfilId = data.perfilId;
+  }
+
   return prisma.usuario.update({
     where: { id: Number(id) },
     data: updateData,

--- a/src/domains/usuario/usuario-service.ts
+++ b/src/domains/usuario/usuario-service.ts
@@ -1,6 +1,6 @@
 // user.service.ts
 import * as userRepository from './usuario-repository';
-import { Usuario, CreateUsuarioInput } from './usuario-entity';
+import { Usuario, CreateUsuarioInput, UpdateUsuarioInput } from './usuario-entity';
 import bcrypt from 'bcryptjs';
 import { toUsuarioResponseDTO } from './dto/UsuarioMapper';
 import { UsuarioResponseDTO } from './dto/UsuarioResponseDTO';
@@ -45,7 +45,10 @@ export async function getUserByIdService(id: number): Promise<UsuarioResponseDTO
   }
 }
 
-export async function updateUserService(id: number, data: Partial<CreateUsuarioInput>): Promise<UsuarioResponseDTO> {
+export async function updateUserService(
+  id: number,
+  data: UpdateUsuarioInput
+): Promise<UsuarioResponseDTO> {
   try {
     const updateData = { ...data };
     if (data.senha) {


### PR DESCRIPTION
## Summary
- support updating `perfilId` and `telefones` in usuario repository
- expose the fields through usuario service
- test updating phones and profile id in service and repository

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c75172a1483319e6999305892986b