### PR TITLE
Use NEXT_PUBLIC_API_URL for web fetch calls

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -34,3 +34,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+The views use the `NEXT_PUBLIC_API_URL` variable as the base URL for all API
+requests. Create a `.env.local` file inside `web` and define the variable when
+the API is hosted elsewhere:
+
+```bash
+NEXT_PUBLIC_API_URL=http://localhost:3000
+```
+
+If the variable is not set, `http://localhost:3000` is used by default.

--- a/web/src/helpers/api.ts
+++ b/web/src/helpers/api.ts
@@ -1,0 +1,2 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+

--- a/web/src/views/LoginForm.tsx
+++ b/web/src/views/LoginForm.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import Input from "@/components/Input";
 import Button from "@/components/Button";
 import ErrorMessage from "@/components/ErrorMessage";
+import { API_URL } from "@/helpers/api";
 
 export default function LoginForm() {
   const [email, setEmail] = useState("");
@@ -16,7 +17,7 @@ export default function LoginForm() {
     setLoading(true);
     document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
     try {
-      const res = await fetch("http://localhost:3000/usuarios/login", {
+      const res = await fetch(`${API_URL}/usuarios/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, senha }),

--- a/web/src/views/PrediosForm.tsx
+++ b/web/src/views/PrediosForm.tsx
@@ -4,6 +4,7 @@ import Input from "@/components/Input";
 import Button from "@/components/Button";
 import Card from "@/components/Card";
 import { getToken } from "@/helpers/auth";
+import { API_URL } from "@/helpers/api";
 
 export default function PrediosForm() {
   const [predios, setPredios] = useState<any[]>([]);
@@ -27,7 +28,7 @@ export default function PrediosForm() {
     setLoading(true);
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/predios", {
+      const res = await fetch(`${API_URL}/predios`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -54,8 +55,8 @@ export default function PrediosForm() {
     try {
       const token = getToken();
       const url = editando
-        ? `http://localhost:3000/predios/${editando.id}`
-        : "http://localhost:3000/predios";
+        ? `${API_URL}/predios/${editando.id}`
+        : `${API_URL}/predios`;
       const method = editando ? "PUT" : "POST";
       const res = await fetch(url, {
         method,
@@ -113,7 +114,7 @@ export default function PrediosForm() {
     if (!confirm("Tem certeza que deseja remover?")) return;
     try {
       const token = getToken();
-      const res = await fetch(`http://localhost:3000/predios/${id}`, {
+      const res = await fetch(`${API_URL}/predios/${id}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
       });

--- a/web/src/views/RecursosForm.tsx
+++ b/web/src/views/RecursosForm.tsx
@@ -4,6 +4,7 @@ import Input from "@/components/Input";
 import Button from "@/components/Button";
 import Card from "@/components/Card";
 import { getToken } from "@/helpers/auth";
+import { API_URL } from "@/helpers/api";
 
 export default function RecursosForm() {
   const [recursos, setRecursos] = useState<any[]>([]);
@@ -22,7 +23,7 @@ export default function RecursosForm() {
     setLoading(true);
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/recursos", {
+      const res = await fetch(`${API_URL}/recursos`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -41,7 +42,7 @@ export default function RecursosForm() {
   async function carregarTipos() {
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/tipos-recurso", {
+      const res = await fetch(`${API_URL}/tipos-recurso`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -65,8 +66,8 @@ export default function RecursosForm() {
     try {
       const token = getToken();
       const url = editando
-        ? `http://localhost:3000/recursos/${editando.id}`
-        : "http://localhost:3000/recursos";
+        ? `${API_URL}/recursos/${editando.id}`
+        : `${API_URL}/recursos`;
       const method = editando ? "PUT" : "POST";
       const res = await fetch(url, {
         method,
@@ -112,7 +113,7 @@ export default function RecursosForm() {
     if (!confirm("Tem certeza que deseja remover?")) return;
     try {
       const token = getToken();
-      const res = await fetch(`http://localhost:3000/recursos/${id}`, {
+      const res = await fetch(`${API_URL}/recursos/${id}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
       });

--- a/web/src/views/ReservasForm.tsx
+++ b/web/src/views/ReservasForm.tsx
@@ -4,6 +4,7 @@ import Input from "@/components/Input";
 import Button from "@/components/Button";
 import Card from "@/components/Card";
 import { getToken } from "@/helpers/auth";
+import { API_URL } from "@/helpers/api";
 
 export default function ReservasForm() {
   const [reservas, setReservas] = useState<any[]>([]);
@@ -22,7 +23,7 @@ export default function ReservasForm() {
     setLoading(true);
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/reservas", {
+      const res = await fetch(`${API_URL}/reservas`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -41,7 +42,7 @@ export default function ReservasForm() {
   async function carregarSalas() {
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/salas", {
+      const res = await fetch(`${API_URL}/salas`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -56,7 +57,7 @@ export default function ReservasForm() {
   async function carregarUsuarios() {
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/usuarios", {
+      const res = await fetch(`${API_URL}/usuarios`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -81,8 +82,8 @@ export default function ReservasForm() {
     try {
       const token = getToken();
       const url = editando
-        ? `http://localhost:3000/reservas/${editando.id}`
-        : "http://localhost:3000/reservas";
+        ? `${API_URL}/reservas/${editando.id}`
+        : `${API_URL}/reservas`;
       const method = editando ? "PUT" : "POST";
       const res = await fetch(url, {
         method,
@@ -128,7 +129,7 @@ export default function ReservasForm() {
     if (!confirm("Tem certeza que deseja remover?")) return;
     try {
       const token = getToken();
-      const res = await fetch(`http://localhost:3000/reservas/${id}`, {
+      const res = await fetch(`${API_URL}/reservas/${id}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
       });

--- a/web/src/views/SalasForm.tsx
+++ b/web/src/views/SalasForm.tsx
@@ -4,6 +4,7 @@ import Input from "@/components/Input";
 import Button from "@/components/Button";
 import Card from "@/components/Card";
 import { getToken } from "@/helpers/auth";
+import { API_URL } from "@/helpers/api";
 
 export default function SalasForm() {
   const [salas, setSalas] = useState([]);
@@ -23,7 +24,7 @@ export default function SalasForm() {
     setLoading(true);
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/salas", {
+      const res = await fetch(`${API_URL}/salas`, {
         headers: { "Authorization": `Bearer ${token}` }
       });
       const data = await res.json();
@@ -44,7 +45,7 @@ export default function SalasForm() {
   async function carregarPredios() {
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/predios", {
+      const res = await fetch(`${API_URL}/predios`, {
         headers: { "Authorization": `Bearer ${token}` }
       });
       const data = await res.json();
@@ -69,8 +70,8 @@ export default function SalasForm() {
     try {
       const token = getToken();
       const url = editando
-        ? `http://localhost:3000/salas/${editando.id}`
-        : "http://localhost:3000/salas";
+        ? `${API_URL}/salas/${editando.id}`
+        : `${API_URL}/salas`;
       const method = editando ? "PUT" : "POST";
       const res = await fetch(url, {
         method,
@@ -118,7 +119,7 @@ export default function SalasForm() {
     if (!confirm("Tem certeza que deseja remover?")) return;
     try {
       const token = getToken();
-      const res = await fetch(`http://localhost:3000/salas/${id}`, {
+      const res = await fetch(`${API_URL}/salas/${id}`, {
         method: "DELETE",
         headers: { "Authorization": `Bearer ${token}` }
       });

--- a/web/src/views/TipoRecursoForm.tsx
+++ b/web/src/views/TipoRecursoForm.tsx
@@ -4,6 +4,7 @@ import Input from "@/components/Input";
 import Button from "@/components/Button";
 import Card from "@/components/Card";
 import { getToken } from "@/helpers/auth";
+import { API_URL } from "@/helpers/api";
 
 export default function TipoRecursoForm() {
   const [tipos, setTipos] = useState<any[]>([]);
@@ -18,7 +19,7 @@ export default function TipoRecursoForm() {
     setLoading(true);
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/tipos-recurso", {
+      const res = await fetch(`${API_URL}/tipos-recurso`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json();
@@ -45,8 +46,8 @@ export default function TipoRecursoForm() {
     try {
       const token = getToken();
       const url = editando
-        ? `http://localhost:3000/tipos-recurso/${editando.id}`
-        : "http://localhost:3000/tipos-recurso";
+        ? `${API_URL}/tipos-recurso/${editando.id}`
+        : `${API_URL}/tipos-recurso`;
       const method = editando ? "PUT" : "POST";
       const res = await fetch(url, {
         method,
@@ -84,7 +85,7 @@ export default function TipoRecursoForm() {
     if (!confirm("Tem certeza que deseja remover?")) return;
     try {
       const token = getToken();
-      const res = await fetch(`http://localhost:3000/tipos-recurso/${id}`, {
+      const res = await fetch(`${API_URL}/tipos-recurso/${id}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
       });

--- a/web/src/views/UsuariosForm.tsx
+++ b/web/src/views/UsuariosForm.tsx
@@ -4,6 +4,7 @@ import Input from "@/components/Input";
 import Button from "@/components/Button";
 import Card from "@/components/Card";
 import { getToken } from "@/helpers/auth";
+import { API_URL } from "@/helpers/api";
 
 export default function UsuariosForm() {
   const [usuarios, setUsuarios] = useState([]);
@@ -27,7 +28,7 @@ export default function UsuariosForm() {
     setLoading(true);
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/usuarios", {
+      const res = await fetch(`${API_URL}/usuarios`, {
         headers: { "Authorization": `Bearer ${token}` }
       });
       const data = await res.json();
@@ -47,7 +48,7 @@ export default function UsuariosForm() {
   async function carregarPerfis() {
     try {
       const token = getToken();
-      const res = await fetch("http://localhost:3000/perfis", {
+      const res = await fetch(`${API_URL}/perfis`, {
         headers: { "Authorization": `Bearer ${token}` }
       });
       const data = await res.json();
@@ -74,9 +75,9 @@ export default function UsuariosForm() {
 
     try {
       const token = getToken();
-      const url = editando 
-        ? `http://localhost:3000/usuarios/${editando.id}`
-        : "http://localhost:3000/usuarios";
+      const url = editando
+        ? `${API_URL}/usuarios/${editando.id}`
+        : `${API_URL}/usuarios`;
       
       const method = editando ? "PUT" : "POST";
       
@@ -160,7 +161,7 @@ export default function UsuariosForm() {
     
     try {
       const token = getToken();
-      const res = await fetch(`http://localhost:3000/usuarios/${id}`, {
+      const res = await fetch(`${API_URL}/usuarios/${id}`, {
         method: "DELETE",
         headers: { "Authorization": `Bearer ${token}` }
       });


### PR DESCRIPTION
## Summary
- add helper exposing `NEXT_PUBLIC_API_URL`
- use API_URL in Next.js views instead of hardcoded localhost
- document environment variable in web README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c752ecbcc8331a5656328132d2830